### PR TITLE
haneke: removing dispatch_sync, cleanup

### DIFF
--- a/Haneke/HNKDiskCache.h
+++ b/Haneke/HNKDiskCache.h
@@ -75,6 +75,14 @@
  */
 - (void)fetchDataForKey:(NSString*)key success:(void (^)(NSData *data))successBlock failure:(void (^)(NSError *error))failureBlock;
 
+/** 
+ Checks the disk for data presence for a given key.
+ @param key Key associated with data.
+ */
+
+- (BOOL)dataExistsForKey:(NSString *)key;
+
+
 #pragma mark Removing data
 ///---------------------------------------------
 /// @name Removing data

--- a/Haneke/HNKDiskCache.m
+++ b/Haneke/HNKDiskCache.m
@@ -104,6 +104,10 @@ NSString *const HNKExtendedFileAttributeKey = @"io.haneke.key";
     });
 }
 
+- (BOOL)dataExistsForKey:(NSString *)key {
+    return [[NSFileManager defaultManager] fileExistsAtPath:[self pathForKey:key]];
+}
+
 #pragma mark Removing data
 
 - (void)removeDataForKey:(NSString*)key


### PR DESCRIPTION
assert on main thread, avoid sync since this is programmer error
remove an additional dispatch_async because threads
add dataExistsForKey to return cache hits
