### PR TITLE
Removed what seems to be a FourSquare specific log. Replaced with NSLog.

### DIFF
--- a/Haneke/HNKCache.m
+++ b/Haneke/HNKCache.m
@@ -389,7 +389,7 @@ NSString *const kHanekeCacheRootPathComponent = @"com.hpique.haneke";
         NSError *error = nil;
         BOOL removedFile = [fileManager removeItemAtPath:[_rootDirectory stringByAppendingPathComponent:filename] error:&error];
         if (!removedFile) {
-            FSLogError(kFSLogTagImages, @"Couldn't drop image cache: %@", error);
+            NSLog(@"Couldn't drop image cache: %@", error);
         }
     }
     


### PR DESCRIPTION
Removed what seems to be a FourSquare specific log. Replaced with NSLog. Needed to do this to be able to compile app.
